### PR TITLE
Detector logic

### DIFF
--- a/src/detector.py
+++ b/src/detector.py
@@ -91,7 +91,7 @@ def torch_thread(weights, img_size, conf_thres=0.2, iou_thres=0.45):
         time.sleep(0.01)
 
 
-def object_detection(label: int, duration: int, opt):
+def object_detection(label: int, duration: int, opt, max_distance: float = 7.0) -> dict:
 
     global image_net, exit_signal, run_signal, detections
 
@@ -204,6 +204,7 @@ def object_detection(label: int, duration: int, opt):
             for obj in object_list:
                 if len(obj.bounding_box) == 0 : continue  
                 if np.isnan(obj.position).any(): continue
+                if obj.position[2] > max_distance: continue  # Filter outliers by distance. Default is 7m
                 if obj.raw_label not in coordinated_target_dict:
                     coordinated_target_dict[obj.raw_label] = np.empty((0,3))
                 coordinated_target_dict[obj.raw_label] = np.vstack([coordinated_target_dict[obj.raw_label], np.array(list(obj.position))])

--- a/src/detector.py
+++ b/src/detector.py
@@ -175,7 +175,7 @@ def object_detection(label: int, duration: int, opt):
     # Set-up Timer
     timeout = time.time() + duration
 
-    coordinated_target_list = np.empty((0,3))
+    coordinated_target_dict = dict()
     while viewer.is_available() and not exit_signal:
 
         if zed.grab(runtime_params) == sl.ERROR_CODE.SUCCESS:
@@ -202,10 +202,11 @@ def object_detection(label: int, duration: int, opt):
 
             object_list = objects.object_list
             for obj in object_list:
-                if obj.raw_label != label: continue
                 if len(obj.bounding_box) == 0 : continue  
                 if np.isnan(obj.position).any(): continue
-                coordinated_target_list = np.vstack([coordinated_target_list, np.array(list(obj.position))])
+                if obj.raw_label not in coordinated_target_dict:
+                    coordinated_target_dict[obj.raw_label] = np.empty((0,3))
+                coordinated_target_dict[obj.raw_label] = np.vstack([coordinated_target_dict[obj.raw_label], np.array(list(obj.position))])
 
             rd.write_history(object_list, label)
             
@@ -243,7 +244,7 @@ def object_detection(label: int, duration: int, opt):
     zed.disable_object_detection()
     zed.close()
 
-    return coordinated_target_list
+    return coordinated_target_dict
 
 def exec_detection(label: str,  opt, duration: int=15):
     object_detection(lab.get_label_id(label), duration, opt)

--- a/src/main.py
+++ b/src/main.py
@@ -44,8 +44,8 @@ def main():
     opt = parser.parse_args()
 
     with torch.no_grad():
-        coordinated_target_list = detector.object_detection(label, 25, opt)
-        angle = find_angle(coordinated_target_list)
+        coordinated_target_dict = detector.object_detection(label, 25, opt)
+        angle = find_angle(coordinated_target_dict[label])
         print("angle :", angle)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changement de logique dans detector.py

- [x] Enlever la responsabilité de filtrer le label de la fonction object_detection
- [x] Retourner un dictionnaire d'objets détectés associés à leurs coordonnées selon le temps
- [x] Ajouter le gestion de outlier dans la fonction object_detection

Notes:

- Le paramètre label est toujours utilisé dans la fonction object_detection, mais pas pour filtrer les objets. 
- Le dictionnaire d'objets utilise le raw_label comme key
- Les outliers sont filtrés par défaut à plus de 7m, mais la distance peut être modifiée

